### PR TITLE
STYLE: Remove "ITK" from the module name.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-project(ITKSmoothingRecursiveYvvGaussianFilter)
+project(SmoothingRecursiveYvvGaussianFilter)
 enable_testing()
 
 if(ITK_USE_GPU)

--- a/CTestConfig.cmake
+++ b/CTestConfig.cmake
@@ -4,7 +4,7 @@
 ## # The following are required to uses Dart and the Cdash dashboard
 ##ENABLE_TESTING()
 ##INCLUDE(CTest)
-set(CTEST_PROJECT_NAME "ITKSmoothingRecursiveYvvGaussianFilter")
+set(CTEST_PROJECT_NAME "SmoothingRecursiveYvvGaussianFilter")
 set(CTEST_NIGHTLY_START_TIME "2:00:00 UTC")
 
 set(CTEST_DROP_METHOD "http")

--- a/include/itkGPUSmoothingRecursiveYvvGaussianImageFilter.h
+++ b/include/itkGPUSmoothingRecursiveYvvGaussianImageFilter.h
@@ -45,7 +45,7 @@ namespace itk
  *  More information in the Insight Journal publication:
  *  http://hdl.handle.net/10380/3425
  *
- * \ingroup ITKSmoothingRecursiveYvvGaussianFilter
+ * \ingroup SmoothingRecursiveYvvGaussianFilter
  */
 
 

--- a/include/itkRecursiveLineYvvGaussianImageFilter.h
+++ b/include/itkRecursiveLineYvvGaussianImageFilter.h
@@ -38,7 +38,7 @@ namespace itk
  *  More information in the Insight Journal publication:
  *  http://hdl.handle.net/10380/3425
  *
- * \ingroup ITKSmoothingRecursiveYvvGaussianFilter
+ * \ingroup SmoothingRecursiveYvvGaussianFilter
  */
  
  

--- a/include/itkSmoothingRecursiveYvvGaussianImageFilter.h
+++ b/include/itkSmoothingRecursiveYvvGaussianImageFilter.h
@@ -42,7 +42,7 @@ namespace itk
  *  More information in the Insight Journal publication:
  *  http://hdl.handle.net/10380/3425
  *
- * \ingroup ITKSmoothingRecursiveYvvGaussianFilter
+ * \ingroup SmoothingRecursiveYvvGaussianFilter
  */
     template <typename TInputImage,
     typename TOutputImage= TInputImage >

--- a/itk-module.cmake
+++ b/itk-module.cmake
@@ -1,8 +1,10 @@
 set(DOCUMENTATION "This module contains a collection of classes for performing
 recursive gaussian filtering (Young Van Vliet implementation).")
 
+
+set(ModuleName "SmoothingRecursiveYvvGaussianFilter")
 if(ITK_USE_GPU)
-    itk_module(ITKSmoothingRecursiveYvvGaussianFilter
+    itk_module(${ModuleName}
      DEPENDS
         ITKCommon
         ITKIOImageBase
@@ -18,7 +20,7 @@ if(ITK_USE_GPU)
          "${DOCUMENTATION}"
     )
 else()
-    itk_module(ITKSmoothingRecursiveYvvGaussianFilter
+    itk_module(${ModuleName}
      DEPENDS
         ITKCommon
         ITKIOImageBase


### PR DESCRIPTION
Following the new naming rules for ITK remote modules,
the remote module name should not contain the "ITK" prefix.
