### PR TITLE
FIX: ITK warnings of deprecated EXCLUDE_FROM_ALL.

### DIFF
--- a/itk-module.cmake
+++ b/itk-module.cmake
@@ -28,7 +28,7 @@ else()
         ITKSmoothing
      TEST_DEPENDS
         ITKTestKernel #to handle IO in src
-     EXCLUDE_FROM_ALL
+     EXCLUDE_FROM_DEFAULT
      DESCRIPTION
          "${DOCUMENTATION}"
     )


### PR DESCRIPTION
EXCLUDE_FROM_ALL is replaced by EXCLUDE_FROM_DEFAULT
in ITK commit:0a98a978509a9536e07c22cde254559cc3c7d417
