### PR TITLE
BUG: Add itk_module_target call for library.

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -23,6 +23,6 @@ if (ITK_USE_GPU)
     add_library(${itk-module} ${GPU_SRC})
     target_link_libraries(${itk-module} ${INRIA_ITK_LIBRARIES} ${OPENCL_LIBRARIES} )
 
-    #itk_module_target(${itk-module})
+    itk_module_target(${itk-module})
 
 endif()


### PR DESCRIPTION
This is required when building against an install tree with GPU support to
avoid linking errors.