### PR TITLE
STYLE: Use Macro for Function Deletion

### DIFF
--- a/include/itkGPUSmoothingRecursiveYvvGaussianImageFilter.h
+++ b/include/itkGPUSmoothingRecursiveYvvGaussianImageFilter.h
@@ -174,12 +174,9 @@ protected:
   GPUDataPointer m_GPUBCoefficientsDataManager;
   GPUDataPointer m_GPULocalDataManager;
 private:
-  GPUSmoothingRecursiveYvvGaussianImageFilter(const Self &);      //purposely
-                                                                  // not
-                                                                  // implemented
-  void BuildKernel();
+  ITK_DISALLOW_COPY_AND_ASSIGN(GPUSmoothingecursiveYvvGaussianImageFilter);
 
-  void operator=(const Self &);      //purposely not implemented
+  void BuildKernel();
 
   /** Normalize the image across scale space */
   bool m_NormalizeAcrossScale;

--- a/include/itkRecursiveLineYvvGaussianImageFilter.h
+++ b/include/itkRecursiveLineYvvGaussianImageFilter.h
@@ -167,8 +167,7 @@ protected:
   // Initialization matrix for anti-causal pass
   vnl_matrix< ScalarRealType > m_MMatrix;
 private:
-  RecursiveLineYvvGaussianImageFilter(const Self &); //purposely not implemented
-  void operator=(const Self &);                      //purposely not implemented
+  ITK_DISALLOW_COPY_AND_ASSIGN(RecursiveLineYvvGaussianImageFilter);
 
   /** Direction in which the filter is to be applied
    * this should be in the range [0,ImageDimension-1]. */

--- a/include/itkSmoothingRecursiveYvvGaussianImageFilter.h
+++ b/include/itkSmoothingRecursiveYvvGaussianImageFilter.h
@@ -168,10 +168,7 @@ protected:
   void EnlargeOutputRequestedRegion(DataObject *output);
 
 private:
-  SmoothingRecursiveYvvGaussianImageFilter(const Self &); //purposely not
-                                                          // implemented
-  void operator=(const Self &);                           //purposely not
-                                                          // implemented
+  ITK_DISALLOW_COPY_AND_ASSIGN(SmoothingRecursiveYvvGaussianImageFilter);
 
   InternalGaussianFilterPointer m_SmoothingFilters[ImageDimension - 1];
   FirstGaussianFilterPointer    m_FirstSmoothingFilter;


### PR DESCRIPTION
Use ITK_DISALLOW_COPY_AND_ASSIGN macro to delete copy and assignment constructors which uses c++11's rigorous function deletion on compilers that support it.