### PR TITLE
COMP: Change include guard and include file style.

### DIFF
--- a/include/itkGPUSmoothingRecursiveYvvGaussianImageFilter.h
+++ b/include/itkGPUSmoothingRecursiveYvvGaussianImageFilter.h
@@ -18,8 +18,8 @@
 
 #ifdef GPU
 
-#ifndef _ITK_GPU_SMOOTHING_RECURSIVE_YVV_GAUSSIAN_IMAGE_FILTER_H_
-#define _ITK_GPU_SMOOTHING_RECURSIVE_YVV_GAUSSIAN_IMAGE_FILTER_H_
+#ifndef itkGPUSmoothingRecursiveYvvGaussianImageFilter_h
+#define itkGPUSmoothingRecursiveYvvGaussianImageFilter_h
 
 #include "itkImage.h"
 #include "itkPixelTraits.h"

--- a/include/itkGPUSmoothingRecursiveYvvGaussianImageFilter.hxx
+++ b/include/itkGPUSmoothingRecursiveYvvGaussianImageFilter.hxx
@@ -1,7 +1,7 @@
 #ifdef GPU
 
-#ifndef _ITK_GPU_SMOOTHING_RECURSIVE_YVV_GAUSSIAN_IMAGE_FILTER_HXX_
-#define _ITK_GPU_SMOOTHING_RECURSIVE_YVV_GAUSSIAN_IMAGE_FILTER_HXX_
+#ifndef itkGPUSmoothingRecursiveYvvGaussianImageFilter_hxx
+#define itkGPUSmoothingRecursiveYvvGaussianImageFilter_hxx
 
 #include "itkGPUSmoothingRecursiveYvvGaussianImageFilter.h"
 

--- a/include/itkRecursiveLineYvvGaussianImageFilter.h
+++ b/include/itkRecursiveLineYvvGaussianImageFilter.h
@@ -16,13 +16,12 @@
 *
 *=========================================================================*/
 
-#pragma once
-#ifndef _ITK_RECURSIVE_LINE_YVV_GAUSSIAN_IMAGE_FILTER_H_
-#define _ITK_RECURSIVE_LINE_YVV_GAUSSIAN_IMAGE_FILTER_H_
+#ifndef itkRecursiveLineYvvGaussianImageFilter_h
+#define itkRecursiveLineYvvGaussianImageFilter_h
 
-#include <itkInPlaceImageFilter.h>
-#include <itkNumericTraits.h>
-#include <itkImageRegionSplitterDirection.h>
+#include "itkInPlaceImageFilter.h"
+#include "itkNumericTraits.h"
+#include "itkImageRegionSplitterDirection.h"
 
 namespace itk
 {

--- a/include/itkRecursiveLineYvvGaussianImageFilter.hxx
+++ b/include/itkRecursiveLineYvvGaussianImageFilter.hxx
@@ -1,6 +1,5 @@
-#pragma once
-#ifndef _ITK_RECURSIVE_LINE_YVV_GAUSSIAN_IMAGE_FILTER_HXX_
-#define _ITK_RECURSIVE_LINE_YVV_GAUSSIAN_IMAGE_FILTER_HXX_
+#ifndef itkRecursiveLineYvvGaussianImageFilter_hxx
+#define itkRecursiveLineYvvGaussianImageFilter_hxx
 
 #include "itkRecursiveLineYvvGaussianImageFilter.h"
 #include "itkObjectFactory.h"

--- a/include/itkSmoothingRecursiveYvvGaussianImageFilter.h
+++ b/include/itkSmoothingRecursiveYvvGaussianImageFilter.h
@@ -15,10 +15,9 @@
 * limitations under the License.
 *
 *=========================================================================*/
-#pragma once
 
-#ifndef _ITK_SMOOTHING_RECURSIVE_YVV_GAUSSIAN_IMAGE_FILTER_H_
-#define _ITK_SMOOTHING_RECURSIVE_YVV_GAUSSIAN_IMAGE_FILTER_H_
+#ifndef itkSmoothingRecursiveYvvGaussianImageFilter_h
+#define itkSmoothingRecursiveYvvGaussianImageFilter_h
 
 #include "itkRecursiveLineYvvGaussianImageFilter.h"
 #include "itkCastImageFilter.h"

--- a/include/itkSmoothingRecursiveYvvGaussianImageFilter.hxx
+++ b/include/itkSmoothingRecursiveYvvGaussianImageFilter.hxx
@@ -1,6 +1,5 @@
-#pragma once
-#ifndef _ITK_SMOOTHING_RECURSIVE_YVV_GAUSSIAN_IMAGE_FILTER_HXX_
-#define _ITK_SMOOTHING_RECURSIVE_YVV_GAUSSIAN_IMAGE_FILTER_HXX_
+#ifndef itkSmoothingRecursiveYvvGaussianImageFilter_hxx
+#define itkSmoothingRecursiveYvvGaussianImageFilter_hxx
 
 #include "itkSmoothingRecursiveYvvGaussianImageFilter.h"
 #include "itkImageRegionIteratorWithIndex.h"


### PR DESCRIPTION
- Use double quote style for module/ITK header file inclusion.
- Remove double underscore in header guards (.h & __itk*_h form). See ITK
  commit:
https://github.com/InsightSoftwareConsortium/ITK/commit/422aa2da236d2333cfb1d0c03ac0fde37bd9822a